### PR TITLE
Stop spamming Sentry on handled Splitwise 404/403

### DIFF
--- a/services/splitwise-auth.ts
+++ b/services/splitwise-auth.ts
@@ -1,7 +1,12 @@
 import * as Sentry from "@sentry/nextjs";
 import { AxiosError } from "axios";
 import type { SplitwiseGroup, SplitwiseUser } from "../types/splitwise";
-import { createSplitwiseAxios, SplitwiseError } from "./splitwise-axios";
+import {
+  createSplitwiseAxios,
+  SplitwiseError,
+  SplitwiseForbiddenError,
+  SplitwiseNotFoundError,
+} from "./splitwise-axios";
 
 export async function validateSplitwiseApiKey(apiKey: string) {
   try {
@@ -88,7 +93,7 @@ export async function getSplitwiseGroup(accessToken: string, groupId: string) {
     };
   } catch (error) {
     // 403 means user doesn't have access to this group
-    if (error instanceof AxiosError && error.response?.status === 403) {
+    if (error instanceof SplitwiseForbiddenError) {
       return {
         success: false,
         error: "No access to group",
@@ -97,7 +102,7 @@ export async function getSplitwiseGroup(accessToken: string, groupId: string) {
     }
 
     // 404 means group doesn't exist
-    if (error instanceof AxiosError && error.response?.status === 404) {
+    if (error instanceof SplitwiseNotFoundError) {
       return {
         success: false,
         error: "Group not found",

--- a/tests/services/splitwise-auth.test.ts
+++ b/tests/services/splitwise-auth.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { http, HttpResponse } from "msw";
+import * as Sentry from "@sentry/nextjs";
+import { getSplitwiseGroup } from "@/services/splitwise-auth";
+import { server } from "../setup";
+
+const SPLITWISE_BASE_URL = "https://secure.splitwise.com/api/v3.0";
+
+describe("getSplitwiseGroup", () => {
+  beforeEach(() => {
+    vi.mocked(Sentry.captureException).mockClear();
+  });
+
+  it("returns { success: false, error: 'Group not found' } on 404 without reporting to Sentry", async () => {
+    server.use(
+      http.get(`${SPLITWISE_BASE_URL}/get_group/:id`, () =>
+        HttpResponse.json(
+          { errors: { base: ["Invalid API Request: record not found"] } },
+          { status: 404 },
+        ),
+      ),
+    );
+
+    const result = await getSplitwiseGroup("token", "999999");
+
+    expect(result).toEqual({
+      success: false,
+      error: "Group not found",
+      group: null,
+    });
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it("returns { success: false, error: 'No access to group' } on 403 without reporting to Sentry", async () => {
+    server.use(
+      http.get(`${SPLITWISE_BASE_URL}/get_group/:id`, () =>
+        HttpResponse.json(
+          { errors: { base: ["You do not have permission"] } },
+          { status: 403 },
+        ),
+      ),
+    );
+
+    const result = await getSplitwiseGroup("token", "123");
+
+    expect(result).toEqual({
+      success: false,
+      error: "No access to group",
+      group: null,
+    });
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it("returns { success: true, group } on 200", async () => {
+    server.use(
+      http.get(`${SPLITWISE_BASE_URL}/get_group/:id`, () =>
+        HttpResponse.json({
+          group: { id: 123, name: "Test", members: [] },
+        }),
+      ),
+    );
+
+    const result = await getSplitwiseGroup("token", "123");
+
+    expect(result.success).toBe(true);
+    expect(result.group).toEqual({ id: 123, name: "Test", members: [] });
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it("reports unexpected errors (5xx) to Sentry and returns failure shape", async () => {
+    server.use(
+      http.get(`${SPLITWISE_BASE_URL}/get_group/:id`, () =>
+        HttpResponse.json({ error: "boom" }, { status: 500 }),
+      ),
+    );
+
+    const result = await getSplitwiseGroup("token", "123");
+
+    expect(result.success).toBe(false);
+    expect(result.group).toBeNull();
+    expect(Sentry.captureException).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Production was firing handled `SplitwiseNotFoundError` (and `SplitwiseForbiddenError`) into Sentry every time a user submitted a stale Splitwise group ID on `POST /dashboard/setup`. The dashboard already converted both into a clean `{ hasAccess: false }` response, so these were noise events with no user impact.

The `splitwise-axios` interceptor wraps all 4xx responses into typed `SplitwiseError` subclasses before rejecting. The catch block in `getSplitwiseGroup` still tested `error instanceof AxiosError && error.response?.status === 404`, so the early-return branches have been dead code since the interceptor was introduced in `9e1fbb9`. Falling through hit `Sentry.captureException` and returned the generic `SplitwiseError` message in place of the original "Group not found" / "No access to group". Matching on the typed subclasses fixes both the noise and the regressed error strings. The unexpected-error path (5xx, network, malformed responses) still reports to Sentry.

Adds `tests/services/splitwise-auth.test.ts` covering the four exit paths (200, 403, 404, 500) and asserting `Sentry.captureException` is not called for the expected 404 and 403 cases.

Sentry issue: 7442059847.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_(1M)-D97757?logo=claude&logoColor=white)